### PR TITLE
[BugFix] UI Dragging and Empty Scripts

### DIFF
--- a/Assets/Scenes/WorldBuilder_Interface.unity
+++ b/Assets/Scenes/WorldBuilder_Interface.unity
@@ -18731,7 +18731,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 456776654}
   m_HandleRect: {fileID: 456776653}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 0.99999994
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -21365,7 +21365,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000031007523, y: -0.000009764278}
+  m_AnchoredPosition: {x: -0.000031007523, y: -0.000003485593}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &2053264365
@@ -21660,7 +21660,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000007526473, y: -410.1}
+  m_AnchoredPosition: {x: 0.00003082496, y: -410.1}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &2067781208

--- a/Assets/Scenes/WorldBuilder_Interface.unity
+++ b/Assets/Scenes/WorldBuilder_Interface.unity
@@ -18112,9 +18112,9 @@ RectTransform:
   m_Father: {fileID: 1314253309}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 80, y: 99.95502}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -880, y: -440.04498}
   m_SizeDelta: {x: 150, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1769326957
@@ -18130,7 +18130,7 @@ GameObject:
   - component: {fileID: 1769326958}
   - component: {fileID: 1769326960}
   m_Layer: 5
-  m_Name: Drag Simbol
+  m_Name: Drag Symbol
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -18731,7 +18731,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 456776654}
   m_HandleRect: {fileID: 456776653}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 0.99999994
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -21365,7 +21365,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000031007523, y: 0.000002648926}
+  m_AnchoredPosition: {x: -0.000031007523, y: -0.000009764278}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &2053264365
@@ -21660,7 +21660,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000008262479, y: -410.1}
+  m_AnchoredPosition: {x: -0.000007526473, y: -410.1}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &2067781208

--- a/Assets/Scripts/Entity System/Scripts/ScriptCatalogUtility.cs
+++ b/Assets/Scripts/Entity System/Scripts/ScriptCatalogUtility.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using UnityEngine.Networking;
+using LitJson;
+using System;
+
+namespace OneGame {
+    using DownloadQueue = Queue<Tuple<ScriptData, string>>;
+
+    /// <summary>
+    /// A collection of utility scripts involving the script catalog
+    /// </summary>
+    internal static class ScriptCatalogUtility {
+
+        /// <summary>
+        /// Downloads a series of scripts from the internet
+        /// </summary>
+        /// <param name="url">The url of the script manifest</param>
+        /// <param name="urlPrefix">The root url</param>
+        /// <param name="onScriptDownload">The event where a script was downloaded</param>
+        /// <param name="onComplete">The event called when the entire process is complete</param>
+        internal static void DownloadScripts (string url, string urlPrefix, Action<ScriptData> onScriptDownload, Action onComplete) {
+            var www = UnityWebRequest.Get (url);
+            var handler = new DownloadHandlerBuffer ();
+            www.downloadHandler = handler;
+            var op = www.SendWebRequest ();
+
+            op.completed += c => {
+                var json = JsonMapper.ToObject (handler.text);
+                var array = json[0];
+                var downloadQueue = new DownloadQueue ();
+
+                for (var i = 0; i < array.Count; ++i) {
+                    var datum = array[i];
+
+                    var scriptData = new ScriptData {
+                        id = (uint)datum["id"],
+                        name = datum["name"].GetString ()
+                    };
+
+                    var scriptUrl = string.Format ("{0}{1}", urlPrefix, datum["asset-path"]);
+                    downloadQueue.Enqueue (new Tuple<ScriptData, string> (scriptData, scriptUrl));
+                }
+
+                ProcessDownloadQueue (downloadQueue, onScriptDownload, onComplete);
+            };
+        }
+
+        private static void ProcessDownloadQueue (DownloadQueue queue, Action<ScriptData> onSuccess, Action onDownloadComplete) {
+            if (queue.Count > 0) {
+                ProcessScriptDownload (queue.Peek (),
+                s => {
+                    onSuccess?.Invoke (s);
+                    queue.Dequeue ();
+                    ProcessDownloadQueue (queue, onSuccess, onDownloadComplete);
+                },
+                () => {
+                    Logger.LogWarningFormat (
+                        "[Script Catalog] <color=red>Skipping '{0}'...this may break saves if it relies on this script</color>",
+                        queue.Peek ().item1.name);
+
+                    queue.Dequeue ();
+                    ProcessDownloadQueue (queue, onSuccess, onDownloadComplete);
+                });
+            } else {
+                onDownloadComplete?.Invoke ();
+            }
+        }
+
+        private static void ProcessScriptDownload (Tuple<ScriptData, string> scriptInfo, Action<ScriptData> onSuccess, Action onFail) {
+            var www = new UnityWebRequest (scriptInfo.item2);
+            var downloadHandler = new DownloadHandlerBuffer ();
+            www.downloadHandler = downloadHandler;
+
+            Logger.LogFormat ("[Script Catalog] Downloading '{0}'...", scriptInfo.item1.name);
+
+            var op = www.SendWebRequest ();
+
+            op.completed += (c) => {
+                if (www.isNetworkError || www.isHttpError) {
+
+                    Logger.LogFormat ("[Script Catalog] <color=red>Error! Cannot download '{0}'!\n{1}...<color>",
+                        scriptInfo.item1.name, www.error);
+
+                    onFail?.Invoke ();
+                } else {
+                    Logger.LogFormat ("[Script Catalog] Downloaded '{0}'", scriptInfo.item1.name);
+
+                    onSuccess?.Invoke (
+                        new ScriptData {
+                            id = scriptInfo.item1.id,
+                            name = scriptInfo.item1.name,
+                            script = downloadHandler.text
+                        });
+                }
+
+                www.Dispose ();
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Entity System/Scripts/ScriptCatalogUtility.cs.meta
+++ b/Assets/Scripts/Entity System/Scripts/ScriptCatalogUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d1345fbbf8d9eb4bb791758e6a78943
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Builder UI/DragSymbol.cs
+++ b/Assets/Scripts/UI/Builder UI/DragSymbol.cs
@@ -1,63 +1,54 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using OneGame;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 
 namespace OneGame.UI {
-	/// <summary>
-	/// UI that show up when start draging from an element inside Library panel
-	/// </summary>
-	public class DragSymbol : MonoBehaviour {
-		[SerializeField]
-		private GameEventTable eventTable;
-		[SerializeField]
-		private Image img;
-		private bool isDragging;
-		private Sprite icon;
-		private RectTransform rect;
+    /// <summary>
+    /// UI that show up when start draging from an element inside Library panel
+    /// </summary>
+    public class DragSymbol : MonoBehaviour {
+        [SerializeField]
+        private GameEventTable eventTable;
+        [SerializeField]
+        private Image img;
+        private Sprite icon;
+        private RectTransform rect;
 
-		private void Start () {
-			gameObject.SetActive (false);
-			isDragging = false;
-			rect = GetComponent<RectTransform> ();
-		}
+        private void Start () {
+            rect = GetComponent<RectTransform> ();
+            gameObject.SetActive (false);
+        }
 
-		private void OnEnable () {
-			eventTable?.Register<Sprite> ("OnElementButtonDragged", StartDrag);
-			eventTable?.Register<uint> ("OnElementButtonDropped", EndDrag);
-		}
+        private void OnEnable () {
+            eventTable?.Register<Sprite> ("OnElementButtonDragged", StartDrag);
+            eventTable?.Register<uint> ("OnElementButtonDropped", EndDrag);
+        }
 
-		private void OnDestroy () {
-			eventTable?.Unregister<Sprite> ("OnElementButtonDragged", StartDrag);
-			eventTable?.Unregister<uint> ("OnElementButtonDropped", EndDrag);
-		}
+        private void OnDestroy () {
+            eventTable?.Unregister<Sprite> ("OnElementButtonDragged", StartDrag);
+            eventTable?.Unregister<uint> ("OnElementButtonDropped", EndDrag);
+        }
 
-		private void Update () {
-			if (isDragging) {
-				rect.anchoredPosition = Input.mousePosition;
-			}
-		}
+        private void Update () {
+            var normalizedMouse = new Vector3 (Input.mousePosition.x / Screen.width, Input.mousePosition.y / Screen.height);
+            rect.anchoredPosition = new Vector2 (normalizedMouse.x * 1920f - 960f, normalizedMouse.y * 1080f - 540f);
+        }
 
-		/// <summary>
-		/// Hide the DragSymbol when the drag is ended
-		/// </summary>
-		/// <param name="id"></param>
-		private void EndDrag (uint id) {
-			isDragging = false;
-			gameObject.SetActive (false);
-		}
+        /// <summary>
+        /// Hide the DragSymbol when the drag is ended
+        /// </summary>
+        /// <param name="id"></param>
+        private void EndDrag (uint id) {
+            gameObject.SetActive (false);
+        }
 
-		/// <summary>
-		/// Sync the dragged icon to the DragSymbol, and show the Drag Symbol when the drag started
-		/// </summary>
-		/// <param name="icon">the icon sprite to switch to</param>
-		private void StartDrag (Sprite icon) {
-			rect.anchoredPosition = Input.mousePosition;
-			isDragging = true;
-			img.sprite = icon;
-			gameObject.SetActive (true);
-
-		}
-	}
+        /// <summary>
+        /// Sync the dragged icon to the DragSymbol, and show the Drag Symbol when the drag started
+        /// </summary>
+        /// <param name="icon">the icon sprite to switch to</param>
+        private void StartDrag (Sprite icon) {
+            rect.anchoredPosition = Input.mousePosition;
+            img.sprite = icon;
+            gameObject.SetActive (true);
+        }
+    }
 }

--- a/Assets/Scripts/UI/Builder UI/Entity Window/EntityScriptSubMenu.cs
+++ b/Assets/Scripts/UI/Builder UI/Entity Window/EntityScriptSubMenu.cs
@@ -7,222 +7,219 @@ using UnityEngine;
 using UnityEngine.UI;
 
 namespace OneGame.UI {
-	public class EntityScriptSubMenu : MonoBehaviour, IEntityWindowComponent {
-		public IEntityContainer Entity { get { return entity; } set { entity = value; } }
-		public EntityWindowComponentType Type { get { return EntityWindowComponentType.Script; } }
+    public class EntityScriptSubMenu : MonoBehaviour, IEntityWindowComponent {
+        public IEntityContainer Entity { get { return entity; } set { entity = value; } }
+        public EntityWindowComponentType Type { get { return EntityWindowComponentType.Script; } }
 
-		[SerializeField]
-		private Dropdown dropdownMenu;
-		[SerializeField]
-		private ScriptCatalog scriptDatabase;
-		[SerializeField]
-		private GameEventTable eventTable;
+        [SerializeField]
+        private Dropdown dropdownMenu;
+        [SerializeField]
+        private ScriptCatalog scriptDatabase;
+        [SerializeField]
+        private GameEventTable eventTable;
 
-		private IEntityContainer entity;
-		private CanvasGroup group;
+        private IEntityContainer entity;
+        private CanvasGroup group;
 
-		private void Awake () {
-			group = GetComponent<CanvasGroup> ();
-		}
+        private void Awake () {
+            group = GetComponent<CanvasGroup> ();
+        }
 
-		private IEnumerator Start () {
-			while (!scriptDatabase.IsReady) {
-				yield return null;
-			}
+        private IEnumerator Start () {
+            while (!scriptDatabase.IsReady) {
+                yield return null;
+            }
 
-			PrepareScriptTemplates ();
-		}
+            PrepareScriptTemplates ();
+        }
 
-		private void OnEnable () {
-			eventTable.Register<IEntityContainer> ("OnScriptApply", RefreshPropertyWindow);
-		}
-		private void OnDisable () {
-			eventTable.Unregister<IEntityContainer> ("OnScriptApply", RefreshPropertyWindow);
-		}
+        private void OnEnable () {
+            eventTable.Register<IEntityContainer> ("OnScriptApply", RefreshPropertyWindow);
+        }
+        private void OnDisable () {
+            eventTable.Unregister<IEntityContainer> ("OnScriptApply", RefreshPropertyWindow);
+        }
 
-		/// <summary>
-		/// Clear script in script editor
-		/// </summary>
-		public void ClearScript () {
-			var script = entity.Script;
-			script.code = string.Empty;
-			script.script.DoString (string.Empty);
-			entity.Script = script;
+        /// <summary>
+        /// Clear script in script editor
+        /// </summary>
+        public void ClearScript () {
+            var script = entity.Script;
+            script.code = string.Empty;
+            script.script.DoString (string.Empty);
+            entity.Script = script;
 
-			eventTable?.Invoke<Tuple<ScriptProperty, Action<string>>[] > (
-				"OnPropertiesInspect", new Tuple<ScriptProperty, Action<string>>[0]);
-		}
+            eventTable?.Invoke<Tuple<ScriptProperty, Action<string>>[]> (
+                "OnPropertiesInspect", new Tuple<ScriptProperty, Action<string>>[0]);
+        }
 
-		/// <summary>
-		/// Close sub menu
-		/// </summary>
-		public void Close () {
-			group.alpha = 0f;
-			group.interactable = false;
-			group.blocksRaycasts = false;
-		}
+        /// <summary>
+        /// Close sub menu
+        /// </summary>
+        public void Close () {
+            group.alpha = 0f;
+            group.interactable = false;
+            group.blocksRaycasts = false;
+        }
 
-		/// <summary>
-		/// pass the entity and script in an event, when user is editing script
-		/// </summary>
-		public void InvokeEditScriptEvent () {
-			eventTable?.Invoke<IEntityContainer, LuaScript> ("OnScriptEditorOpen", entity, entity.Script);
-		}
+        /// <summary>
+        /// pass the entity and script in an event, when user is editing script
+        /// </summary>
+        public void InvokeEditScriptEvent () {
+            eventTable?.Invoke<IEntityContainer, LuaScript> ("OnScriptEditorOpen", entity, entity.Script);
+        }
 
-		/// <summary>
-		/// open the menu and invoke an event to pass selected script properties
-		/// </summary>
-		public void Open () {
-			group.alpha = 1f;
-			group.interactable = true;
-			group.blocksRaycasts = true;
+        /// <summary>
+        /// open the menu and invoke an event to pass selected script properties
+        /// </summary>
+        public void Open () {
+            group.alpha = 1f;
+            group.interactable = true;
+            group.blocksRaycasts = true;
 
-			eventTable?.Invoke<Tuple<ScriptProperty, Action<string>>[] > (
-				"OnPropertiesInspect", CreateScriptProperties (entity.Script.properties, entity.Script.script));
-		}
+            eventTable?.Invoke<Tuple<ScriptProperty, Action<string>>[]> (
+                "OnPropertiesInspect", CreateScriptProperties (entity.Script.properties, entity.Script.script));
+        }
 
-		/// <summary>
-		/// refresh the property window by invoking the event
-		/// </summary>
-		/// <param name="entity">the entity that is selected</param>
-		public void RefreshPropertyWindow (IEntityContainer entity) {
-			eventTable?.Invoke<Tuple<ScriptProperty, Action<string>>[] > (
-				"OnPropertiesInspect", CreateScriptProperties (entity.Script.properties, entity.Script.script));
-		}
+        /// <summary>
+        /// refresh the property window by invoking the event
+        /// </summary>
+        /// <param name="entity">the entity that is selected</param>
+        public void RefreshPropertyWindow (IEntityContainer entity) {
+            eventTable?.Invoke<Tuple<ScriptProperty, Action<string>>[]> (
+                "OnPropertiesInspect", CreateScriptProperties (entity.Script.properties, entity.Script.script));
+        }
 
-		/// <summary>
-		/// create property gameobject on the ui from the script's variables
-		/// </summary>
-		/// <param name="extract"></param>
-		/// <param name="script"></param>
-		/// <returns></returns>
-		private Tuple<ScriptProperty, Action<string>>[] CreateScriptProperties (ScriptProperty[] extract, Script script) {
-			if (extract == null) {
-				extract = ScriptUtility.ExtractProperties (script);
-			}
+        /// <summary>
+        /// create property gameobject on the ui from the script's variables
+        /// </summary>
+        /// <param name="extract"></param>
+        /// <param name="script"></param>
+        /// <returns></returns>
+        private Tuple<ScriptProperty, Action<string>>[] CreateScriptProperties (ScriptProperty[] extract, Script script) {
+            if (extract == null) {
+                extract = ScriptUtility.ExtractProperties (script);
+            }
 
-			var properties = new Tuple<ScriptProperty, Action<string>>[extract.Length];
+            var properties = new Tuple<ScriptProperty, Action<string>>[extract.Length];
 
-			for (var i = 0; i < properties.Length; ++i) {
-				var index = i;
-				var prop = extract[index];
-				Action<string> callback = null;
+            for (var i = 0; i < properties.Length; ++i) {
+                var index = i;
+                var prop = extract[index];
+                Action<string> callback = null;
 
-				switch (prop.type) {
-					case PropertyType.Boolean:
-						callback = s => {
-							prop.value = s;
-							extract[index] = prop;
-							ScriptUtility.ApplyProperties (script, extract);
-						};
-						break;
+                switch (prop.type) {
+                    case PropertyType.Boolean:
+                        callback = s => {
+                            prop.value = s;
+                            extract[index] = prop;
+                            ScriptUtility.ApplyProperties (script, extract);
+                        };
+                        break;
 
-					case PropertyType.Number:
-						callback = s => {
-							var num = default (double);
-							if (double.TryParse (s, out num)) {
-								prop.value = s.ToString ();
-								extract[index] = prop;
-								ScriptUtility.ApplyProperties (script, extract);
-							}
-						};
-						break;
+                    case PropertyType.Number:
+                        callback = s => {
+                            var num = default (double);
+                            if (double.TryParse (s, out num)) {
+                                prop.value = s.ToString ();
+                                extract[index] = prop;
+                                ScriptUtility.ApplyProperties (script, extract);
+                            }
+                        };
+                        break;
 
-					case PropertyType.String:
-						callback = s => {
-							prop.value = s;
-							extract[index] = prop;
-							ScriptUtility.ApplyProperties (script, extract);
-						};
-						break;
-				}
+                    case PropertyType.String:
+                        callback = s => {
+                            prop.value = s;
+                            extract[index] = prop;
+                            ScriptUtility.ApplyProperties (script, extract);
+                        };
+                        break;
+                }
 
-				properties[i] = new Tuple<ScriptProperty, Action<string>> (prop, callback);
-			}
+                properties[i] = new Tuple<ScriptProperty, Action<string>> (prop, callback);
+            }
 
-			return properties;
-		}
+            return properties;
+        }
 
-		private Property[] GetProperties (Script script) {
-			var table = script.Globals;
-			var propList = new List<Property> ();
+        private Property[] GetProperties (Script script) {
+            var table = script.Globals;
+            var propList = new List<Property> ();
 
-			foreach (var tableKey in table.Keys) {
-				var key = tableKey;
-				var value = table.Get (key);
-				var p = new Property {
-					name = key.String.Replace ("\"", "")
-				};
+            foreach (var tableKey in table.Keys) {
+                var key = tableKey;
+                var value = table.Get (key);
+                var p = new Property {
+                    name = key.String.Replace ("\"", "")
+                };
 
-				switch (value.Type) {
-					case DataType.Boolean:
-						p.type = PropertyType.Boolean;
-						p.value = value.Boolean.ToString ();
-						p.onPropertyEdit = s => { table.Set (key, DynValue.NewBoolean (s == "true")); };
-						propList.Add (p);
-						break;
+                switch (value.Type) {
+                    case DataType.Boolean:
+                        p.type = PropertyType.Boolean;
+                        p.value = value.Boolean.ToString ();
+                        p.onPropertyEdit = s => { table.Set (key, DynValue.NewBoolean (s == "true")); };
+                        propList.Add (p);
+                        break;
 
-					case DataType.Number:
-						p.type = PropertyType.Number;
-						p.value = value.Number.ToString ();
-						p.onPropertyEdit = s => {
-							var number = default (double);
-							if (double.TryParse (s, out number)) {
-								table.Set (key, DynValue.NewNumber (number));
-							}
-						};
-						propList.Add (p);
-						break;
+                    case DataType.Number:
+                        p.type = PropertyType.Number;
+                        p.value = value.Number.ToString ();
+                        p.onPropertyEdit = s => {
+                            var number = default (double);
+                            if (double.TryParse (s, out number)) {
+                                table.Set (key, DynValue.NewNumber (number));
+                            }
+                        };
+                        propList.Add (p);
+                        break;
 
-					case DataType.String:
-						p.type = PropertyType.String;
-						p.value = value.String;
-						p.onPropertyEdit = s => table.Set (key, DynValue.NewString (s));
-						propList.Add (p);
-						break;
-				}
-			}
+                    case DataType.String:
+                        p.type = PropertyType.String;
+                        p.value = value.String;
+                        p.onPropertyEdit = s => table.Set (key, DynValue.NewString (s));
+                        propList.Add (p);
+                        break;
+                }
+            }
 
-			return propList.ToArray ();
-		}
+            return propList.ToArray ();
+        }
 
-		private void PrepareScriptTemplates () {
-			var scripts = scriptDatabase.Scripts;
+        private void PrepareScriptTemplates () {
+            var scripts = scriptDatabase.Scripts;
 
-			var options = new List<Dropdown.OptionData> ();
-			for (var i = 0; i < scripts.Length; ++i) {
-				options.Add (new Dropdown.OptionData {
-					text = scripts[i].name
-				});
-			}
+            var options = new List<Dropdown.OptionData> ();
+            for (var i = 0; i < scripts.Length; ++i) {
+                options.Add (new Dropdown.OptionData {
+                    text = scripts[i].name
+                });
+            }
 
-			dropdownMenu.ClearOptions ();
-			dropdownMenu.AddOptions (options);
+            dropdownMenu.ClearOptions ();
+            dropdownMenu.AddOptions (options);
 
-			dropdownMenu.onValueChanged.AddListener (i => {
-				var overwrite = scriptDatabase.Scripts[i];
-				var script = entity.Script;
-				var isValidated = true;
+            dropdownMenu.onValueChanged.AddListener (i => {
+                var overwrite = scriptDatabase.Scripts[i];
+                var script = entity.Script;
+                var isValidated = true;
+                try {
+                    script.script.DoString (overwrite.script);
+                } catch {
+                    Debug.LogWarning ("Error on code!");
+                    isValidated = false;
+                }
 
-				// TODO: Find a way to properly "nuke" the old properties
+                // If the code passes the Moonsharp text, finalize the script values
+                if (isValidated) {
+                    script.code = overwrite.script;
+                    script.properties = ScriptUtility.ExtractProperties (script.script);
+                    entity.Script = script;
 
-				try {
-					script.script.DoString (overwrite.script);
-				} catch {
-					Debug.LogWarning ("Error on code!");
-					isValidated = false;
-				}
-
-				// If the code passes the Moonsharp text, finalize the script values
-				if (isValidated) {
-					script.code = overwrite.script;
-					script.properties = ScriptUtility.ExtractProperties (script.script);
-					entity.Script = script;
-
-					eventTable?.Invoke<Tuple<ScriptProperty, Action<string>>[] > ("OnPropertiesInspect", CreateScriptProperties (script.properties, script.script));
-					eventTable?.Invoke<IEntityContainer, LuaScript> ("OnScriptEditorOpen", entity, entity.Script);
-				}
-			});
-		}
-	}
+                    eventTable?.Invoke<Tuple<ScriptProperty, Action<string>>[]> ("OnPropertiesInspect", CreateScriptProperties (script.properties, script.script));
+                    eventTable?.Invoke<IEntityContainer, LuaScript> ("OnScriptEditorOpen", entity, entity.Script);
+                }
+            });
+        }
+    }
 }


### PR DESCRIPTION
Fixes Issues #3 and #5 

Causes: 
 * For #3, The script to drag the symbol does not take into account for resolutions smaller than 1920x1080.
 * For #5, The ScriptCatalog does not take into account what happens when the queued script fails to download (404 error) and thus returns an empty string.

Solutions:
  * Adds scaling support for dragging symbols
  * Adds checks for the final script list to ignore scripts that failed to download